### PR TITLE
Add Ajolocoin token base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # ajolocoin
- 
+
+Base del proyecto para la criptomoneda **Ajolocoin** en la red Atom.
+Cada token generado incluye una característica aleatoria de un ajolote.
+
+## Uso rápido
+
+```bash
+go run ./cmd/ajolocoincli --id 42
+```
+
+Ejemplo de salida:
+
+```
+Token 42 con característica Albino
+```
+

--- a/cmd/ajolocoincli/main.go
+++ b/cmd/ajolocoincli/main.go
@@ -1,30 +1,15 @@
 package main
 
 import (
-	"os"
+	"flag"
+	"fmt"
 
-	"github.com/ajolocoin/app"
-	"github.com/ajolocoin/cmd/myajolocoind/cmd"
-	"github.com/cosmos/cosmos-sdk/server"
-	"github.com/cosmos/cosmos-sdk/version"
+	"ajolocoin/token"
 )
 
 func main() {
-	// Configura la aplicación
-	app.Setup()
-
-	// Añade los comandos específicos de tu aplicación
-	rootCmd, _ := cmd.NewRootCmd()
-
-	// Añade el comando de inicio de servidor
-	executor := server.NewCommand(rootCmd)
-
-	// Añade la versión del software
-	executor.Version = version.Version
-	executor.Commit = version.Commit
-
-	// Inicia el servidor
-	if err := executor.Execute(); err != nil {
-		os.Exit(1)
-	}
+	id := flag.String("id", "1", "ID del token")
+	flag.Parse()
+	t := token.Mint(*id)
+	fmt.Printf("Token %s con característica %s\n", t.ID, t.Characteristic)
 }

--- a/cmd/ajolocoinind/main.go
+++ b/cmd/ajolocoinind/main.go
@@ -1,1 +1,7 @@
-package ajolocoinind
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Ajolocoin node placeholder")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module ajolocoin
 
 go 1.21.0
-
-require github.com/cosmos/cosmos-sdk v0.47.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/cosmos/cosmos-sdk v0.47.4 h1:FVUpEprm58nMmBX4xkRdMDaIG5Nr4yy92HZAfGAw9bg=
-github.com/cosmos/cosmos-sdk v0.47.4/go.mod h1:R5n+uM7vguVPFap4pgkdvQCT1nVo/OtPwrlAU40rvok=

--- a/token/token.go
+++ b/token/token.go
@@ -1,0 +1,28 @@
+package token
+
+import (
+	"math/rand"
+	"time"
+)
+
+type Token struct {
+	ID             string
+	Characteristic string
+}
+
+var Characteristics = []string{
+	"Albino",
+	"Leucístico",
+	"Melanoide",
+	"Dorado",
+	"Salvaje",
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func Mint(id string) Token {
+	trait := Characteristics[rand.Intn(len(Characteristics))]
+	return Token{ID: id, Characteristic: trait}
+}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,0 +1,17 @@
+package token
+
+import "testing"
+
+func TestMint(t *testing.T) {
+	tkn := Mint("1")
+	found := false
+	for _, c := range Characteristics {
+		if tkn.Characteristic == c {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Característica inválida: %s", tkn.Characteristic)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement token package that mints Ajolocoin tokens with random axolotl traits
- Add simple CLI and node placeholders for minting tokens
- Document quick usage in README

## Testing
- `go test ./...`
- `go run ./cmd/ajolocoincli --id 42`


------
https://chatgpt.com/codex/tasks/task_e_68bbb0adde4c832b97b9f3f3ffb43dc8